### PR TITLE
Use stateName as the source of truth for StackRouterNavigator state e…

### DIFF
--- a/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/StackRouterNavigator.kt
+++ b/android/libraries/rib-router-navigator/src/main/kotlin/com/uber/rib/core/StackRouterNavigator.kt
@@ -296,7 +296,7 @@ constructor(
     var found = false
     var navigationIterator = navigationStack.iterator()
     while (navigationIterator.hasNext()) {
-      if (navigationIterator.next().state == newState) {
+      if (navigationIterator.next().state.stateName() == newState.stateName()) {
         found = true
         break
       }
@@ -305,7 +305,7 @@ constructor(
       navigationIterator = navigationStack.iterator()
       while (navigationIterator.hasNext()) {
         val routerAndState = navigationIterator.next()
-        if (routerAndState.state == newState) {
+        if (routerAndState.state.stateName() == newState.stateName()) {
           attachInternal(currentRouterAndState, routerAndState, true)
           break
         } else {
@@ -329,7 +329,7 @@ constructor(
     val navigationIterator = navigationStack.iterator()
     while (navigationIterator.hasNext()) {
       val routerAndState = navigationIterator.next()
-      if (routerAndState.state == newState) {
+      if (routerAndState.state.stateName() == newState.stateName()) {
         navigationIterator.remove()
         navigationStack.push(routerAndState)
         attachInternal(currentRouterAndState, routerAndState, true)
@@ -347,7 +347,7 @@ constructor(
   private fun removeStateFromStack(state: StateT) {
     val navigationIterator = navigationStack.iterator()
     while (navigationIterator.hasNext()) {
-      if (navigationIterator.next().state == state) {
+      if (navigationIterator.next().state.stateName() == state.stateName()) {
         navigationIterator.remove()
       }
     }


### PR DESCRIPTION
…quality

**Description**:
Currently, StackRouterNavigator compares states inconsistently. In the "pushState" method, it compares states via "state.stateName() == newState.stateName()". Elsewhere, it compares states using "state == newState". This leads to surprising behavior in the library.

For example, if you push state with name "A", then push another state "A" with Flag.DEFAULT, the second push will no-op even if the two states aren't otherwise equal. But if you push a state with name "A", then push another state with Flag.CLEAR_TOP, clearTop won't clear the stack since a different equality check is used vs Flag.DEFAULT.

This makes the library always use the state name as the source of truth for state equality, which seems like a more expected behavior.


<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**: RF-8841
